### PR TITLE
Updated to force using mongo:4.4 to keep it working

### DIFF
--- a/deployment-mongo-a.yaml
+++ b/deployment-mongo-a.yaml
@@ -16,7 +16,7 @@ spec:
         application: mongo-a
     spec:
       containers: 
-        - image: mongo
+        - image: mongo:4.4
           name: mongo-a
           command:
             - mongod

--- a/deployment-mongo-b.yaml
+++ b/deployment-mongo-b.yaml
@@ -16,7 +16,7 @@ spec:
         application: mongo-b
     spec:
       containers: 
-        - image: mongo
+        - image: mongo:4.4
           name: mongo-b
           command:
             - mongod

--- a/deployment-mongo-c.yaml
+++ b/deployment-mongo-c.yaml
@@ -16,7 +16,7 @@ spec:
         application: mongo-c
     spec:
       containers: 
-        - image: mongo
+        - image: mongo:4.4
           name: mongo-c
           command:
             - mongod


### PR DESCRIPTION
Mongodb 5.0 was released this week and current example does not work as is.
I am fixing it by specifying the working version for this current example and I will
research how to make it compatible with 5.0 in an upcoming PR.